### PR TITLE
Add move number to move history

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -82,7 +82,7 @@
                 var historyElement = $('#move-history').empty();
                 historyElement.empty();
                 for (var i = 0; i < moves.length; i = i + 2) {
-                    historyElement.append('<span>' + moves[i] + ' ' + ( moves[i + 1] ? moves[i + 1] : ' ') + '</span><br>')
+                    historyElement.append('<span>' + (1 + i / 2) + '. ' + moves[i] + ' ' + ( moves[i + 1] ? moves[i + 1] : ' ') + '</span><br>')
                 }
                 historyElement.scrollTop(historyElement[0].scrollHeight);
 


### PR DESCRIPTION
Add missing move number to move history, to follow FIDE standard algebraic notation.
I't also better for usability - quick orientation in moves.